### PR TITLE
Update events & add missing events

### DIFF
--- a/rosetta/events.yml
+++ b/rosetta/events.yml
@@ -37,6 +37,12 @@ games:
         singleplayer: false
       callback:
         parameters:
+        - name: target
+          type: IsoPlayer
+          notes: Player who accepted the trade.
+        - name: requester
+          type: IsoPlayer
+          notes: Player who requested the trade.
         - name: accepted
           type: boolean
           notes: Whether the trade was accepted.
@@ -334,6 +340,11 @@ games:
         parameters:
         - name: message
           type: string
+          note: Message describing the error.
+        - name: detail
+          type: string | nil
+          note: Additional detail about the error. This is currently only provided for
+            workshop errors.
     - name: OnConnected
       notes: Triggered after successfully connecting to a server on the main menu,
         before character creation begins.
@@ -838,7 +849,7 @@ games:
           notes: The weather stage that was created.
         - name: strength
           type: number
-          # TODO: what is this?
+          notes: The intensity of the weather stage.
     - name: OnInitRecordedMedia
       notes: Triggered when RecordedMedia is initialised.
       callback:
@@ -1263,7 +1274,7 @@ games:
         - name: damageType
           type: '"POISON" | "HUNGRY" | "SICK" | "BLEEDING" | "THIRST" | "HEAVYLOAD"
             | "INFECTION" | "LOWWEIGHT" | "FALLDOWN" | "WEAPONHIT" | "CARHITDAMAGE"
-            | "CARCRASHDAMAGE"'
+            | "CARCRASHDAMAGE" | "FIRE"'
           notes: The type of damage the character took.
         - name: damage
           type: number
@@ -1518,7 +1529,7 @@ games:
         - name: logs
           type: ArrayList<UserLog>
         - name: suspiciousActivity
-          type: table<string, string>
+          type: table<string, string> | nil
           notes: Key is name of anticheat, value is number of times triggered (as a string for some reason).
     - name: OnRefreshInventoryWindowContainers
       notes: Triggered when the available containers in the inventory UI change.
@@ -1612,6 +1623,8 @@ games:
           type: ArrayList<String>
         - name: steamIDs
           type: ArrayList<String>
+        - name: pingValues
+          type: ArrayList<number>
     - name: OnSeeNewRoom
       notes: Triggered when a room becomes visible for the first time.
       callback:
@@ -1678,8 +1691,8 @@ games:
         - name: type
           type: string
         - name: items
-          type: ArrayList<String> | ArrayList<SteamUGCDetails> | string | integer
-            | nil
+          type: "ArrayList<String> | ArrayList<SteamUGCDetails> | string | integer
+            | nil"
         - name: error
           type: string | integer | nil
         - name: maxSize
@@ -1708,7 +1721,7 @@ games:
       callback:
         parameters:
         - name: regions
-          type: table
+          type: umbrella.SpawnRegion[]
     - name: OnSteamFriendStatusChanged
       notes: Triggered when the player has gained or lost a steam friend.
       context:
@@ -1739,12 +1752,13 @@ games:
         parameters:
         - name: address
           type: string
+          notes: IP address of the server.
         - name: port
           type: number
+          notes: Port of the server.
         - name: rules
-          type: table
+          type: umbrella.ServerProperties
           notes: 'Table of information about the server' 
-          # TODO: investigate what this actually is, class definition?'
     - name: OnSteamServerResponded
       notes: Triggered when receiving a server for the server list.
       context:
@@ -1944,10 +1958,6 @@ games:
         - name: vehicle
           type: BaseVehicle
           notes: The vehicle being used.
-        - name: pressedNotTapped
-          type: boolean
-          notes: True if the button was held for a short duration, false if the button
-            was tapped.
     - name: OnVehicleDamageTexture
       notes: Triggered when a vehicle part has become damaged enough to gain a damage
         overlay.
@@ -2179,10 +2189,15 @@ games:
         singleplayer: false
       callback:
         parameters:
-        - name: factionName
-          type: string
+        - name: faction
+          type: Faction
+          notes: Faction the client is being invited to.
         - name: hostUsername
           type: string
+          notes: Username of the faction leader.
+        - name: invitedUsername
+          type: string
+          notes: Username of the player being invited.
     - name: ReceiveSafehouseInvite
       notes: Triggered when the client receives a safehouse invite.
       context:
@@ -2190,10 +2205,15 @@ games:
         singleplayer: false
       callback:
         parameters:
-        - name: title
-          type: string
+        - name: safehouse
+          type: SafeHouse
+          notes: Safehouse the client is being invited to.
         - name: hostUsername
           type: string
+          notes: Username of the safehouse owner.
+        - name: invitedUsername
+          type: string
+          notes: Username of the player being invited.
     - name: RequestTrade
       notes: Triggered when the client receives a trade request.
       context:
@@ -2202,7 +2222,11 @@ games:
       callback:
         parameters:
         - name: requester
-          type: string
+          type: IsoPlayer
+          notes: Player who requested the trade.
+        - name: target
+          type: IsoPlayer
+          notes: Player receiving the trade request.
     - name: ReuseGridsquare
       notes: Triggered before a square is unloaded.
       callback:
@@ -2252,9 +2276,12 @@ games:
         singleplayer: false
       callback:
         parameters:
-        - name: player
+        - name: otherPlayer
           type: IsoPlayer
           notes: The player who added the item.
+        - name: player
+          type: IsoPlayer
+          notes: The local player who owns the trading UI.
         - name: item
           type: InventoryItem
           notes: The item that was added.
@@ -2265,9 +2292,12 @@ games:
         singleplayer: false
       callback:
         parameters:
-        - name: player
+        - name: otherPlayer
           type: IsoPlayer
           notes: The player who removed the item.
+        - name: player
+          type: IsoPlayer
+          notes: The local player who owns the trading UI.
         - name: id
           type: integer
           notes: The id of the removed item.
@@ -2278,9 +2308,12 @@ games:
         singleplayer: false
       callback:
         parameters:
-        - name: player
+        - name: otherPlayer
           type: IsoPlayer
           notes: The player changing the state.
+        - name: player
+          type: IsoPlayer
+          notes: The local player who owns the trading UI.
         - name: state
           type: integer
           notes: The new state.
@@ -2293,7 +2326,7 @@ games:
       callback:
         parameters:
         - name: tickets
-          type: ArrayList
+          type: ArrayList<DBTicket>
     - name: OnContextKey
       notes: Triggered while the player is holding the context key.
       context:
@@ -2342,7 +2375,7 @@ games:
         parameters:
           - name: message
             type: string
-            # TODO: unsure of contents
+            notes: Status message for registration of the Google auth key.
       context:
         client: true
         singleplayer: false
@@ -2481,7 +2514,7 @@ games:
           type: IsoPlayer
         - name: itemType
           type: string
-        - name: amount
+        - name: distanceTraveled
           type: number
     - name: SetDragItem
       context:

--- a/rosetta/events.yml
+++ b/rosetta/events.yml
@@ -683,6 +683,21 @@ games:
           type: ItemContainer | ItemPickerJava.ItemPickerContainer
           notes: The container that was filled. An ItemPickerContainer is sometimes
             passed when a sub-container is spawned and filled, and is probably a bug.
+    - name: OnFillInventoryContextMenuNoItems
+      notes: Triggered after the context menu for no items has been filled.
+      context:
+        server: false
+      callback:
+        parameters:
+        - name: playerIndex
+          type: integer
+          notes: The index of the player whose context menu has been filled.
+        - name: context
+          type: ISContextMenu
+          notes: The context menu that was filled.
+        - name: isLoot
+          type: boolean
+          notes: Whether the context menu was filled for a loot inventory window.
     - name: OnFillInventoryObjectContextMenu
       notes: Triggered after the context menu for an inventory item is filled.
       context:
@@ -736,6 +751,38 @@ games:
           type: boolean
           notes: Whether the context menu was filled to test for interactive objects
             on the square. If true, the context menu will not actually be displayed.
+    - name: OnForagePool
+      notes: Triggered when a foraging pool is received from the server.
+      context:
+        server: false
+      callback:
+        parameters:
+        - name: player
+          type: IsoPlayer
+        - name: zoneId
+          type: string
+        - name: icons
+          type: table<string, umbrella.Foraging.PoolRecord>
+    - name: OnForageRequestZone
+      notes: Triggered when a request from the client is received to send forage pools.
+      context:
+        client: false
+      callback:
+        parameters:
+        - name: player
+          type: IsoPlayer
+        - name: focus
+          type: string
+    - name: OnForageSpot
+      notes: Triggered on the server when a client sends that they've spotted a foraging icon.
+      context:
+        client: false
+      callback:
+        parameters:
+        - name: player
+          type: IsoPlayer
+        - name: iconID
+          type: string
     - name: OnGameBoot
       notes: 'Triggered after the game finishes starting up. Note: For clients, lua
         files in lua/server/ will not have ran by the time this event is triggered,
@@ -934,6 +981,16 @@ games:
         - name: joypadId
           type: integer
           notes: ID of the joypad.
+    - name: OnJoypadDebugRenderUIOptionSet
+      notes: Triggered when rendering controller debug UI.
+      context:
+        server: false
+      callback:
+        parameters:
+        - name: debugDrawUI
+          type: boolean
+        - name: debugDrawNavigation
+          type: boolean
     - name: OnJoypadReactivate
       notes: Triggered after a controller has been connected.
       context:
@@ -1385,6 +1442,22 @@ games:
           notes: The items that were selected to fill the context menu. If only full
             stacks are selected, a table of ContextMenuItemStacks is passed. Otherwise
             it is a table of InventoryItems.
+    - name: OnPreFillInventoryContextMenuNoItems
+      notes: Triggered when the context menu for no items is created,
+        before it is filled.
+      context:
+        server: false
+      callback:
+        parameters:
+        - name: playerIndex
+          type: integer
+          notes: The index of the player whose context menu has been created.
+        - name: context
+          type: ISContextMenu
+          notes: The context menu that was created.
+        - name: isLoot
+          type: boolean
+          notes: Whether the context menu was created for a loot inventory window.
     - name: OnPreFillWorldObjectContextMenu
       notes: Triggered after the world context menu is created, before it is filled.
       context:
@@ -2147,6 +2220,22 @@ games:
         - name: zombie
           type: IsoZombie
           notes: The zombie being updated.
+    - name: OptionControllerButtonStyleChanged
+      notes: Triggered when the controller button style option is changed.
+      context:
+        server: false
+      callback:
+        parameters:
+        - name: newOption
+          type: string
+    - name: OptionGamepadBindingPresetChanged
+      notes: Triggered when the gamepad binding preset option is changed.
+      context:
+        server: false
+      callback:
+        parameters:
+        - name: newOption
+          type: string
     - name: preAddCatDefs
       notes: Triggered before the foraging system processes item category definitions.
       callback:


### PR DESCRIPTION
Updated event callback types to reflect 42.20. Also added some missing events, not including those already in #7:

- OnFillInventoryContextMenuNoItems
- OnForagePool
- OnForageRequestZone
- OnForageSpot
- OnJoypadDebugRenderUIOptionSet
- OnPreFillInventoryContextMenuNoItems
- OptionControllerButtonStyleChanged
- OptionGamepadBindingPresetChanged
